### PR TITLE
Fix the logo in the title 💎

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#<img src="img/logo.png"> Ruby Trivia
+# <img src="img/logo.png"> Ruby Trivia
 
 A list of questions about Ruby programming you can use to quiz yourself.
 


### PR DESCRIPTION
There is a space missing between the hash (number) sign and the image tag in the title.

## Before

![before](https://user-images.githubusercontent.com/2473081/94558527-a1d6df00-0268-11eb-9c7e-358701c1d037.png)

## After

![after](https://user-images.githubusercontent.com/2473081/94558545-a8655680-0268-11eb-9b13-4d6b40b617a5.png)
