### PR TITLE
Unify Fixnum and Bignum into Integer 🐌

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,6 @@ A: Strings are mutable while symbols are immutable. Though Ruby internally makes
 ### Numeric
 
 Q: Symbols are immutable objects. Name another immutable core Ruby object.  
-A: `Fixnum`
-
-Q: What happens when a value becomes too big for `Fixnum`?  
-A: It is automatically converted to a `Bignum`.
-
-Q: What is the superclass of `Fixnum`?  
 A: `Integer`
 
 Q: What is the superclass of `Integer`?  


### PR DESCRIPTION
Though ISO/IEC 30170:2012 doesn’t specify details of the Integer class, Ruby had two visible Integer classes: Fixnum and Bignum.

Ruby 2.4 (released in 2016) unified them into Integer.

https://www.ruby-lang.org/en/news/2016/12/25/ruby-2-4-0-released/
http://www.a-k-r.org/pub/2016-09-08-rubykaigi-unified-integer.pdf